### PR TITLE
feat: restart from head, refactor & qol

### DIFF
--- a/cmd/yaci/extract.go
+++ b/cmd/yaci/extract.go
@@ -2,12 +2,12 @@ package yaci
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/liftedinit/yaci/internal/client"
@@ -68,13 +68,13 @@ func extract(address string, outputHandler output.OutputHandler) error {
 	slog.Info("Fetching protocol buffer descriptors from gRPC server... This may take a while.")
 	descriptors, err := reflection.FetchAllDescriptors(ctx, grpcConn, maxRetries)
 	if err != nil {
-		return errors.WithMessage(err, "failed to fetch descriptors")
+		return fmt.Errorf("failed to fetch descriptors: %w", err)
 	}
 
 	slog.Info("Building protocol buffer descriptor set...")
 	files, err := reflection.BuildFileDescriptorSet(descriptors)
 	if err != nil {
-		return errors.WithMessage(err, "failed to build descriptor set")
+		return fmt.Errorf("failed to build descriptor set: %w", err)
 	}
 
 	resolver := reflection.NewCustomResolver(files, grpcConn, ctx, maxRetries)
@@ -83,13 +83,13 @@ func extract(address string, outputHandler output.OutputHandler) error {
 		slog.Info("Starting live extraction", "block_time", blockTime)
 		err = extractor.ExtractLiveBlocksAndTransactions(ctx, grpcConn, resolver, start, outputHandler, blockTime, maxConcurrency, maxRetries)
 		if err != nil {
-			return errors.WithMessage(err, "failed to process live blocks and transactions")
+			return fmt.Errorf("failed to process live blocks and transactions: %w", err)
 		}
 	} else {
 		slog.Info("Starting extraction", "start", start, "stop", stop)
 		err = extractor.ExtractBlocksAndTransactions(ctx, grpcConn, resolver, start, stop, outputHandler, maxConcurrency, maxRetries)
 		if err != nil {
-			return errors.WithMessage(err, "failed to process blocks and transactions")
+			return fmt.Errorf("failed to process blocks and transactions: %w", err)
 		}
 	}
 

--- a/cmd/yaci/json.go
+++ b/cmd/yaci/json.go
@@ -1,9 +1,9 @@
 package yaci
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/liftedinit/yaci/internal/output"
@@ -18,12 +18,12 @@ var jsonCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := os.MkdirAll(jsonOut, 0755)
 		if err != nil {
-			return errors.WithMessage(err, "failed to create output directory")
+			return fmt.Errorf("failed to create output directory: %w", err)
 		}
 
 		outputHandler, err := output.NewJSONOutputHandler(jsonOut)
 		if err != nil {
-			return errors.WithMessage(err, "failed to create JSON output handler")
+			return fmt.Errorf("failed to create JSON output handler: %w", err)
 		}
 		defer outputHandler.Close()
 

--- a/cmd/yaci/tsv.go
+++ b/cmd/yaci/tsv.go
@@ -1,9 +1,9 @@
 package yaci
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/liftedinit/yaci/internal/output"
@@ -18,12 +18,12 @@ var tsvCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := os.MkdirAll(tsvOut, 0755)
 		if err != nil {
-			return errors.WithMessage(err, "failed to create output directory")
+			return fmt.Errorf("failed to create output directory: %w", err)
 		}
 
 		outputHandler, err := output.NewTSVOutputHandler(tsvOut)
 		if err != nil {
-			return errors.WithMessage(err, "failed to create TSV output handler")
+			return fmt.Errorf("failed to create TSV output handler: %w", err)
 		}
 		defer outputHandler.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.1
 require (
 	github.com/golang/protobuf v1.5.0
 	github.com/jackc/pgx/v4 v4.18.3
-	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v1.8.1
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.1

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/liftedinit/yaci/internal/models"
 )
 
@@ -22,12 +20,12 @@ func NewJSONOutputHandler(outDir string) (*JSONOutputHandler, error) {
 
 	err := os.MkdirAll(blockDir, 0755)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to create blocks directory")
+		return nil, fmt.Errorf("failed to create blocks directory: %w", err)
 	}
 
 	err = os.MkdirAll(txDir, 0755)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to create transactions directory")
+		return nil, fmt.Errorf("failed to create transactions directory: %w", err)
 	}
 
 	return &JSONOutputHandler{
@@ -36,13 +34,27 @@ func NewJSONOutputHandler(outDir string) (*JSONOutputHandler, error) {
 	}, nil
 }
 
-func (h *JSONOutputHandler) WriteBlock(ctx context.Context, block *models.Block) error {
+func (h *JSONOutputHandler) WriteBlockWithTransactions(_ context.Context, block *models.Block, transactions []*models.Transaction) error {
+	if err := h.writeBlock(block); err != nil {
+		return fmt.Errorf("failed to write block: %w", err)
+	}
+
+	for _, tx := range transactions {
+		if err := h.writeTransaction(tx); err != nil {
+			return fmt.Errorf("failed to write transaction: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (h *JSONOutputHandler) writeBlock(block *models.Block) error {
 	fileName := fmt.Sprintf("block_%010d.json", block.ID)
 	filePath := filepath.Join(h.blockDir, fileName)
 	return os.WriteFile(filePath, block.Data, 0644)
 }
 
-func (h *JSONOutputHandler) WriteTransaction(ctx context.Context, tx *models.Transaction) error {
+func (h *JSONOutputHandler) writeTransaction(tx *models.Transaction) error {
 	fileName := fmt.Sprintf("tx_%s.json", tx.Hash)
 	filePath := filepath.Join(h.txDir, fileName)
 	return os.WriteFile(filePath, tx.Data, 0644)

--- a/internal/output/output_handler.go
+++ b/internal/output/output_handler.go
@@ -7,7 +7,6 @@ import (
 )
 
 type OutputHandler interface {
-	WriteBlock(ctx context.Context, block *models.Block) error
-	WriteTransaction(ctx context.Context, tx *models.Transaction) error
+	WriteBlockWithTransactions(ctx context.Context, block *models.Block, transactions []*models.Transaction) error
 	Close() error
 }

--- a/internal/output/postgresql.go
+++ b/internal/output/postgresql.go
@@ -3,11 +3,11 @@ package output
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/pkg/errors"
-
 	"github.com/liftedinit/yaci/internal/models"
 )
 
@@ -21,19 +21,71 @@ type PostgresOutputHandler struct {
 func NewPostgresOutputHandler(connString string) (*PostgresOutputHandler, error) {
 	pool, err := pgxpool.Connect(context.Background(), connString)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to connect to PostgreSQL")
+		return nil, fmt.Errorf("failed to connect to PostgreSQL: %w", err)
 	}
 
 	handler := &PostgresOutputHandler{
 		pool: pool,
 	}
 
-	// Initialize tables
+	// Initialize tables. This is idempotent.
 	if err := handler.initTables(); err != nil {
-		return nil, errors.WithMessage(err, "failed to initialize tables")
+		return nil, fmt.Errorf("failed to initialize tables: %w", err)
 	}
 
 	return handler, nil
+}
+
+func (h *PostgresOutputHandler) GetLatestBlock(ctx context.Context) (*models.Block, error) {
+	var block models.Block
+	err := h.pool.QueryRow(ctx, `
+		SELECT id
+		FROM api.blocks
+		ORDER BY id DESC
+		LIMIT 1
+	`).Scan(&block.ID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil // No rows found
+		}
+		return nil, fmt.Errorf("failed to get the latest block: %w", err)
+	}
+	return &block, nil
+}
+
+func (h *PostgresOutputHandler) WriteBlockWithTransactions(ctx context.Context, block *models.Block, transactions []*models.Transaction) error {
+	tx, err := h.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) // Ensure rollback if commit is not reached
+
+	// Write block
+	_, err = tx.Exec(ctx, `
+		INSERT INTO api.blocks (id, data) VALUES ($1, $2)
+		ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;
+	`, block.ID, block.Data)
+	if err != nil {
+		return fmt.Errorf("failed to write blockchain block: %w", err)
+	}
+
+	// Write transactions
+	for _, txData := range transactions {
+		_, err = tx.Exec(ctx, `
+			INSERT INTO api.transactions (id, data) VALUES ($1, $2)
+			ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;
+		`, txData.Hash, txData.Data)
+		if err != nil {
+			return fmt.Errorf("failed to write blockchain transaction: %w", err)
+		}
+	}
+
+	// Commit transaction
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
 }
 
 func (h *PostgresOutputHandler) initTables() error {
@@ -41,24 +93,6 @@ func (h *PostgresOutputHandler) initTables() error {
 	slog.Info("Initializing PostgreSQL tables")
 	ctx := context.Background()
 	_, err := h.pool.Exec(ctx, initSQL)
-	return err
-}
-
-func (h *PostgresOutputHandler) WriteBlock(ctx context.Context, block *models.Block) error {
-	slog.Debug("Writing block", "id", block.ID)
-	_, err := h.pool.Exec(ctx, `
-        INSERT INTO api.blocks (id, data) VALUES ($1, $2)
-        ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;
-    `, block.ID, block.Data)
-	return err
-}
-
-func (h *PostgresOutputHandler) WriteTransaction(ctx context.Context, tx *models.Transaction) error {
-	slog.Debug("Writing transaction", "hash", tx.Hash)
-	_, err := h.pool.Exec(ctx, `
-        INSERT INTO api.transactions (id, data) VALUES ($1, $2)
-        ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;
-    `, tx.Hash, tx.Data)
 	return err
 }
 

--- a/internal/reflection/build_descriptor.go
+++ b/internal/reflection/build_descriptor.go
@@ -3,7 +3,6 @@ package reflection
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -22,18 +21,18 @@ func BuildFileDescriptorSet(descriptors []*descriptorpb.FileDescriptorProto) (*p
 	// Perform a topological sort of the file descriptors
 	sortedDescriptors, err := topologicalSort(fdMap)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to sort file descriptors")
+		return nil, fmt.Errorf("failed to sort file descriptors: %w", err)
 	}
 
 	// Register the sorted descriptors
 	for _, fdProto := range sortedDescriptors {
 		fd, err := protodesc.NewFile(fdProto, files)
 		if err != nil {
-			return nil, errors.WithMessage(err, "failed to create file descriptor")
+			return nil, fmt.Errorf("failed to create file descriptor: %w", err)
 		}
 
 		if err := files.RegisterFile(fd); err != nil {
-			return nil, errors.WithMessage(err, "failed to register file descriptor")
+			return nil, fmt.Errorf("failed to register file descriptor: %w", err)
 		}
 	}
 


### PR DESCRIPTION
- Use `fmt.Errorf` to wrap errors
- Atomic transaction (PostgreSQL only)
  - A block and all related transactions are committed to the database in a single transaction
- Restart indexing from where we left off
- Fix off-by-one
- Avoid displaying a gazillion message when context is cancelled

TODO
- [ ] Add option to perform full re-index
- [ ] More cleanup/QoL