### PR TITLE
feat: add rpc endpoint to return token-related txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 `yaci` is a command-line tool that connects to a gRPC server and extracts blockchain data.
 
-Tested with Cosmos SDK v0.50.x.
-
 ## Use-case
 
 Off-chain indexing of block & transaction data.
@@ -16,6 +14,7 @@ Off-chain indexing of block & transaction data.
 
 - Go 1.23.1
 - Docker & Docker Compose (optional)
+- CosmosSDK >= 0.50 (chain to index)
 
 ## Features
 
@@ -75,6 +74,20 @@ The following flags are available for all `extract` subcommand:
 
 Extract blockchain data and output it to a PostgreSQL database.
 
+The PostgreSQL database has the following schema:
+
+```mermaid
+erDiagram:
+  api.blocks {
+    serial id PK
+    jsonb data
+  }
+  api.transactions {
+    varchar(64) id PK
+    jsonb data
+  }
+```
+
 #### Usage
 
 ```
@@ -93,6 +106,12 @@ yaci extract postgres localhost:9090 -p postgres://postgres:foobar@localhost/pos
 ```
 
 This command will connect to the gRPC server running on `localhost:9090`, continuously extract data from block height `106000` and store the extracted data in the `postgres` database. New blocks and transactions will be inserted into the database every 5 seconds.
+
+#### PostgreSQL Functions
+
+The following PostgreSQL functions are available:
+
+- `get_address_filtered_transactions_and_successful_proposals(address)`: Returns filtered transactions and successful proposals for a given address.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ The PostgreSQL database has the following schema:
 
 ```mermaid
 erDiagram
-  api.blocks {
+  "api.blocks" {
     serial id PK
     jsonb data
   }
-  api.transactions {
+  "api.transactions" {
     varchar(64) id PK
     jsonb data
   }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Extract blockchain data and output it to a PostgreSQL database.
 The PostgreSQL database has the following schema:
 
 ```mermaid
-erDiagram:
+erDiagram
   api.blocks {
     serial id PK
     jsonb data

--- a/internal/output/postgresql.go
+++ b/internal/output/postgresql.go
@@ -15,6 +15,9 @@ import (
 //go:embed sql/init.sql
 var initSQL string
 
+//go:embed sql/get_txs.sql
+var getTxsSQL string
+
 type PostgresOutputHandler struct {
 	pool *pgxpool.Pool
 }
@@ -32,6 +35,11 @@ func NewPostgresOutputHandler(connString string) (*PostgresOutputHandler, error)
 	// Initialize tables. This is idempotent.
 	if err := handler.initTables(); err != nil {
 		return nil, fmt.Errorf("failed to initialize tables: %w", err)
+	}
+
+	// Initialize functions. This is idempotent.
+	if err := handler.initFunctions(); err != nil {
+		return nil, fmt.Errorf("failed to initialize functions: %w", err)
 	}
 
 	return handler, nil
@@ -121,6 +129,14 @@ func (h *PostgresOutputHandler) initTables() error {
 	slog.Info("Initializing PostgreSQL tables")
 	ctx := context.Background()
 	_, err := h.pool.Exec(ctx, initSQL)
+	return err
+}
+
+func (h *PostgresOutputHandler) initFunctions() error {
+	// Create functions if they don't exist
+	slog.Info("Initializing PostgreSQL functions")
+	ctx := context.Background()
+	_, err := h.pool.Exec(ctx, getTxsSQL)
 	return err
 }
 

--- a/internal/output/sql/get_txs.sql
+++ b/internal/output/sql/get_txs.sql
@@ -46,7 +46,11 @@ submit_proposals AS (
     ) AS proposal_attr ON TRUE
   WHERE
     msg.value ->> '@type' = '/cosmos.group.v1.MsgSubmitProposal'
-    AND msg.value::text ILIKE '%' || address || '%'
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(msg.value -> 'messages') AS nested_msg(value)
+      WHERE nested_msg.value::text ILIKE '%' || address || '%'
+    )
     AND EXISTS (
       SELECT 1
       FROM jsonb_array_elements(msg.value -> 'messages') AS nested_msg(value)

--- a/internal/output/sql/get_txs.sql
+++ b/internal/output/sql/get_txs.sql
@@ -1,0 +1,102 @@
+CREATE OR REPLACE FUNCTION api.get_transactions(address TEXT)
+RETURNS TABLE (id VARCHAR(64), data JSONB)
+AS $$
+WITH base_messages AS (
+  SELECT
+    t.id,
+    t.data,
+    msg.value AS message
+  FROM
+    api.transactions t,
+    LATERAL jsonb_array_elements(t.data -> 'tx' -> 'body' -> 'messages') AS msg(value)
+  WHERE
+    -- Exclude messages that are MsgSubmitProposal
+    msg.value ->> '@type' != '/cosmos.group.v1.MsgSubmitProposal'
+),
+filtered_messages AS (
+  SELECT
+    id,
+    data
+  FROM
+    base_messages
+  WHERE
+    -- Include only desired message types
+    message ->> '@type' IN (
+      '/cosmos.bank.v1beta1.MsgSend',
+      '/osmosis.tokenfactory.v1beta1.MsgMint',
+      '/osmosis.tokenfactory.v1beta1.MsgBurn'
+    )
+    -- Check if the message contains the given address anywhere in its content
+    AND message::text ILIKE '%' || address || '%'
+),
+submit_proposals AS (
+  SELECT
+    t.id AS submit_id,
+    t.data AS submit_data,
+    proposal_attr.attr ->> 'value' AS proposal_id
+  FROM
+    api.transactions t
+    JOIN LATERAL jsonb_array_elements(t.data -> 'tx' -> 'body' -> 'messages') AS msg(value) ON TRUE
+    JOIN LATERAL (
+      SELECT attr
+      FROM jsonb_array_elements(t.data -> 'txResponse' -> 'events') AS event,
+           jsonb_array_elements(event -> 'attributes') AS attr
+      WHERE event ->> 'type' = 'cosmos.group.v1.EventSubmitProposal'
+        AND attr ->> 'key' = 'proposal_id'
+    ) AS proposal_attr ON TRUE
+  WHERE
+    msg.value ->> '@type' = '/cosmos.group.v1.MsgSubmitProposal'
+    AND msg.value::text ILIKE '%' || address || '%'
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(msg.value -> 'messages') AS nested_msg(value)
+      WHERE nested_msg.value ->> '@type' IN (
+        '/cosmos.bank.v1beta1.MsgSend',
+        '/osmosis.tokenfactory.v1beta1.MsgMint',
+        '/osmosis.tokenfactory.v1beta1.MsgBurn',
+        '/liftedinit.manifest.v1.MsgPayout',
+        '/liftedinit.manifest.v1.MsgBurnHeldBalance'
+      )
+    )
+),
+execs AS (
+  SELECT
+    t.id AS exec_id,
+    t.data AS exec_data,
+    attrs.attr_map ->> 'proposal_id' AS proposal_id,
+    attrs.attr_map ->> 'result' AS result
+  FROM
+    api.transactions t
+    JOIN LATERAL (
+      SELECT event
+      FROM jsonb_array_elements(t.data -> 'txResponse' -> 'events') AS event
+      WHERE event ->> 'type' = 'cosmos.group.v1.EventExec'
+      LIMIT 1
+    ) AS exec_event ON TRUE
+    JOIN LATERAL (
+      SELECT jsonb_object_agg(attr ->> 'key', attr ->> 'value') AS attr_map
+      FROM jsonb_array_elements(exec_event.event -> 'attributes') AS attr
+    ) AS attrs(attr_map) ON TRUE
+),
+matching_proposals AS (
+  SELECT
+    sp.submit_id AS id,
+    sp.submit_data AS data
+  FROM
+    submit_proposals sp
+    JOIN execs e ON sp.proposal_id = e.proposal_id
+)
+SELECT DISTINCT
+  id,
+  data
+FROM
+  filtered_messages
+
+UNION
+
+SELECT DISTINCT
+  id,
+  data
+FROM
+  matching_proposals;
+$$ LANGUAGE SQL STABLE;

--- a/internal/output/sql/get_txs.sql
+++ b/internal/output/sql/get_txs.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION api.get_transactions(address TEXT)
+CREATE OR REPLACE FUNCTION api.get_address_filtered_transactions_and_successful_proposals(address TEXT)
 RETURNS TABLE (id VARCHAR(64), data JSONB)
 AS $$
 WITH base_messages AS (


### PR DESCRIPTION
This function returns transactions

- Mentioning `manifest1...` in the `data->tx->messages` field
- Of types `MsgSend`, `MsgMint`, `MsgBurn`
- Of type `MsgSubmitProposal` that have
  - At lease one nested message of type `MsgSend`, `MsgMint`,
    `MsgBurn`, `MsgPayout` or `MsgBurnHeldBalance`
  - An associated `MsgExec` (same `proposal_id`) with an executor status
    of `PROPOSAL_EXECUTOR_RESULT_SUCCESS`

When using PostgREST, call using

```
/rpc/get_address_filtered_transactions_and_successful_proposals?address=manifest1...
```