### PR TITLE
fix: rpc to return more transactions for history

### DIFF
--- a/internal/output/sql/get_txs.sql
+++ b/internal/output/sql/get_txs.sql
@@ -1,108 +1,124 @@
 CREATE OR REPLACE FUNCTION api.get_address_filtered_transactions_and_successful_proposals(address TEXT)
 RETURNS TABLE (id VARCHAR(64), data JSONB)
+LANGUAGE SQL STABLE
 AS $$
-WITH base_messages AS (
+WITH
+-- 1) Expand transactions => messages containing `address`
+base_messages AS (
   SELECT
     t.id,
     t.data,
     msg.value AS message
-  FROM
-    api.transactions t,
-    LATERAL jsonb_array_elements(t.data -> 'tx' -> 'body' -> 'messages') AS msg(value)
-  WHERE
-    -- Exclude messages that are MsgSubmitProposal
-    msg.value ->> '@type' != '/cosmos.group.v1.MsgSubmitProposal'
+  FROM api.transactions t
+  CROSS JOIN LATERAL jsonb_array_elements(t.data -> 'tx' -> 'body' -> 'messages') AS msg(value)
+  WHERE msg.value::text ILIKE '%' || address || '%'
 ),
-filtered_messages AS (
-  SELECT
-    id,
-    data
-  FROM
-    base_messages
-  WHERE
-    -- Include only desired message types
-    message ->> '@type' IN (
-      '/cosmos.bank.v1beta1.MsgSend',
-      '/osmosis.tokenfactory.v1beta1.MsgMint',
-      '/osmosis.tokenfactory.v1beta1.MsgBurn'
-    )
-    -- Check if the message contains the given address anywhere in its content
-    AND message::text ILIKE '%' || address || '%'
+
+-- 2) All successful transactions (code=0)
+all_successful_txs AS (
+  SELECT DISTINCT
+    bm.id,
+    bm.data
+  FROM base_messages bm
+  WHERE COALESCE((bm.data -> 'txResponse' ->> 'code')::INT, 0) = 0
 ),
-submit_proposals AS (
-  SELECT
-    t.id AS submit_id,
-    t.data AS submit_data,
-    proposal_attr.attr ->> 'value' AS proposal_id
-  FROM
-    api.transactions t
-    JOIN LATERAL jsonb_array_elements(t.data -> 'tx' -> 'body' -> 'messages') AS msg(value) ON TRUE
-    JOIN LATERAL (
-      SELECT attr
-      FROM jsonb_array_elements(t.data -> 'txResponse' -> 'events') AS event,
-           jsonb_array_elements(event -> 'attributes') AS attr
-      WHERE event ->> 'type' = 'cosmos.group.v1.EventSubmitProposal'
-        AND attr ->> 'key' = 'proposal_id'
-    ) AS proposal_attr ON TRUE
-  WHERE
-    msg.value ->> '@type' = '/cosmos.group.v1.MsgSubmitProposal'
-    AND EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(msg.value -> 'messages') AS nested_msg(value)
-      WHERE nested_msg.value::text ILIKE '%' || address || '%'
-    )
-    AND EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(msg.value -> 'messages') AS nested_msg(value)
-      WHERE nested_msg.value ->> '@type' IN (
-        '/cosmos.bank.v1beta1.MsgSend',
-        '/osmosis.tokenfactory.v1beta1.MsgMint',
-        '/osmosis.tokenfactory.v1beta1.MsgBurn',
-        '/liftedinit.manifest.v1.MsgPayout',
-        '/liftedinit.manifest.v1.MsgBurnHeldBalance'
+
+-- 3) Errored transactions (code != 0)
+--    Only keep if at least one message references `address`
+--    in one of the allowed fields.
+errored_with_address AS (
+  SELECT DISTINCT
+    bm.id,
+    bm.data
+  FROM base_messages bm
+  WHERE COALESCE((bm.data -> 'txResponse' ->> 'code')::INT, 0) != 0
+    AND (
+      bm.message ->> 'sender'       = address
+      OR bm.message ->> 'fromAddress' = address
+      OR bm.message ->> 'admin'     = address
+      OR bm.message ->> 'voter'     = address
+      OR bm.message ->> 'address'   = address
+      OR (
+        bm.message ? 'proposers'
+        AND address IN (
+          SELECT jsonb_array_elements_text(bm.message -> 'proposers')
+        )
       )
     )
 ),
+
+-- 4) Identify submitted proposals (MsgSubmitProposal), capturing proposal_id.
+submit_proposals AS (
+  SELECT
+    bm.id AS submit_id,
+    bm.data AS submit_data,
+    proposal_attr.attr ->> 'value' AS proposal_id
+  FROM base_messages bm
+  CROSS JOIN LATERAL jsonb_array_elements(bm.data -> 'tx' -> 'body' -> 'messages') AS msg(value)
+  JOIN LATERAL (
+    SELECT attr
+    FROM jsonb_array_elements(bm.data -> 'txResponse' -> 'events') AS event,
+         jsonb_array_elements(event -> 'attributes') AS attr
+    WHERE event ->> 'type' = 'cosmos.group.v1.EventSubmitProposal'
+      AND attr ->> 'key' = 'proposal_id'
+    LIMIT 1
+  ) AS proposal_attr ON TRUE
+  WHERE msg.value ->> '@type' = '/cosmos.group.v1.MsgSubmitProposal'
+),
+
+-- 5) Find successful executions (EventExec) with a matching proposal_id.
 execs AS (
   SELECT
-    t.id AS exec_id,
-    t.data AS exec_data,
+    bm.id AS exec_id,
+    bm.data AS exec_data,
     attrs.attr_map ->> 'proposal_id' AS proposal_id,
     attrs.attr_map ->> 'result' AS result
-  FROM
-    api.transactions t
-    JOIN LATERAL (
-      SELECT event
-      FROM jsonb_array_elements(t.data -> 'txResponse' -> 'events') AS event
-      WHERE event ->> 'type' = 'cosmos.group.v1.EventExec'
-      LIMIT 1
-    ) AS exec_event ON TRUE
-    JOIN LATERAL (
-      SELECT jsonb_object_agg(attr ->> 'key', attr ->> 'value') AS attr_map
-      FROM jsonb_array_elements(exec_event.event -> 'attributes') AS attr
-    ) AS attrs(attr_map) ON TRUE
+  FROM base_messages bm
+  CROSS JOIN LATERAL (
+    SELECT event
+    FROM jsonb_array_elements(bm.data -> 'txResponse' -> 'events') AS event
+    WHERE event ->> 'type' = 'cosmos.group.v1.EventExec'
+    LIMIT 1
+  ) AS exec_event
+  JOIN LATERAL (
+    SELECT jsonb_object_agg(attr ->> 'key', attr ->> 'value') AS attr_map
+    FROM jsonb_array_elements(exec_event.event -> 'attributes') AS attr
+  ) AS attrs(attr_map) ON TRUE
 ),
+
+-- 6) matching_proposals = transactions that submitted a proposal
+--    which was successfully executed.
 matching_proposals AS (
-  SELECT
+  SELECT DISTINCT
     sp.submit_id AS id,
     sp.submit_data AS data
-  FROM
-    submit_proposals sp
-    JOIN execs e ON sp.proposal_id = e.proposal_id
+  FROM submit_proposals sp
+  JOIN execs e
+    ON sp.proposal_id = e.proposal_id
+  -- optionally: AND e.result = 'PROPOSAL_EXECUTE_SUCCESS'
 )
+
+-- 7) Final SELECT:
+--    (a) All successful transactions
+--    (b) Errored transactions that reference `address` in allowed fields
+--    (c) Successfully executed proposals
 SELECT DISTINCT id, data
-FROM
-(
-  SELECT
-    id,
-    data
-  FROM filtered_messages
-  WHERE COALESCE((data->'txResponse'->>'code')::int, 0) = 0
+FROM (
+  -- (a) All successful transactions
+  SELECT id, data
+  FROM all_successful_txs
+
   UNION
-  SELECT
-    id,
-    data
+
+  -- (b) Errored transactions that reference `address` in allowed fields
+  SELECT id, data
+  FROM errored_with_address
+
+  UNION
+
+  -- (c) Successfully executed proposals (submission must be code=0)
+  SELECT id, data
   FROM matching_proposals
-  WHERE COALESCE((data->'txResponse'->>'code')::int, 0) = 0
+  WHERE COALESCE((data -> 'txResponse' ->> 'code')::INT, 0) = 0
 ) combined;
-$$ LANGUAGE SQL STABLE;
+$$;

--- a/internal/output/sql/get_txs.sql
+++ b/internal/output/sql/get_txs.sql
@@ -95,7 +95,7 @@ matching_proposals AS (
   FROM submit_proposals sp
   JOIN execs e
     ON sp.proposal_id = e.proposal_id
-  -- optionally: AND e.result = 'PROPOSAL_EXECUTE_SUCCESS'
+  WHERE e.result = '"PROPOSAL_EXECUTOR_RESULT_SUCCESS"'
 )
 
 -- 7) Final SELECT:


### PR DESCRIPTION
The `get_address_filtered_transactions_and_successful_proposals` endpoint now returns

- All successful transactions containing the given address
- Errored transactions ONLY if some allowed fields contain the given address
- Transactions from successfully executed proposals containing the given address

We want to be able to track

- Fees for any successful transaction
- Fees for failed transactions (transaction sender only)
- Transactions directly impacting your balance (send, mint, burn, ...)
- Any transaction from a successfully executed proposal and impacting your balance

TODO
- [ ] Add tests
- [ ] Implement change in FE