### PR TITLE
fix: don't force earliest block height to 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-GO_VERSION: &go_version '1.23.1'
+GO_VERSION: &go_version '1.23.6'
 GORELEASER_VERSION: &goreleaser_version 'v1.26.2'
 GO_MOD_CACHE_KEY: &go_mod_cache_key 'go-mod-1'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liftedinit/yaci
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/go-resty/resty/v2 v2.16.4

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -100,11 +100,22 @@ func initializeGRPC(ctx context.Context, address string, cfg config.ExtractConfi
 func setBlockRange(ctx context.Context, grpcConn *grpc.ClientConn, resolver *reflection.CustomResolver, outputHandler output.OutputHandler, cfg *config.ExtractConfig) error {
 	if cfg.ReIndex {
 		slog.Info("Reindexing entire database...")
+		// TODO: Get the earliest block from the gRPC server
+		// See https://github.com/liftedinit/yaci/issues/28
 		cfg.BlockStart = 1
+		earliestLocalBlock, err := outputHandler.GetEarliestBlock(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get the earliest local block: %w", err)
+		}
+		if earliestLocalBlock != nil {
+			cfg.BlockStart = earliestLocalBlock.ID
+		}
 		cfg.BlockStop = 0
 	}
 
 	if cfg.BlockStart == 0 {
+		// TODO: Get the earliest block from the gRPC server
+		// See https://github.com/liftedinit/yaci/issues/28
 		cfg.BlockStart = 1
 		latestLocalBlock, err := outputHandler.GetLatestBlock(ctx)
 		if err != nil {

--- a/internal/output/output_handler.go
+++ b/internal/output/output_handler.go
@@ -13,6 +13,9 @@ type OutputHandler interface {
 	// GetLatestBlock returns the latest block from the output.
 	GetLatestBlock(ctx context.Context) (*models.Block, error)
 
+	// GetEarliestBlock returns the earliest block from the output.
+	GetEarliestBlock(ctx context.Context) (*models.Block, error)
+
 	// GetMissingBlockIds returns the missing block IDs from the output.
 	GetMissingBlockIds(ctx context.Context) ([]uint64, error)
 


### PR DESCRIPTION
This PR fixes the missing block detection by removing the `minimum block height = 1` constraint.

Reindexing the database will attempt to start from the earliest block stored instead of `block height = 1`.

This PR acts as a workaround for #28. One should now be able to use YACI on chains where the `earliest block height != 1` by manually specifying the starting block using the `-s` parameter.

Tested on CosmosHub Mainnet with

```
yaci extract postgres -s 24200000 -t 6 --live -k cosmos-grpc.polkachu.com:14990
```

Subsequent runs can omit the `-s` parameter as YACI will retrieve the earliest block from the database.