### PR TITLE
feat: max grpc recv msg size cli setting

### DIFF
--- a/cmd/yaci/extract.go
+++ b/cmd/yaci/extract.go
@@ -22,13 +22,11 @@ func init() {
 	ExtractCmd.PersistentFlags().UintP("block-time", "t", 2, "Block time in seconds")
 	ExtractCmd.PersistentFlags().UintP("max-retries", "r", 3, "Maximum number of retries for failed block processing")
 	ExtractCmd.PersistentFlags().UintP("max-concurrency", "c", 100, "Maximum block retrieval concurrency (advanced)")
+	ExtractCmd.PersistentFlags().IntP("max-recv-msg-size", "m", 4194304, "Maximum gRPC message size in bytes (advanced)")
 
 	if err := viper.BindPFlags(ExtractCmd.PersistentFlags()); err != nil {
 		slog.Error("Failed to bind ExtractCmd flags", "error", err)
 	}
 
-	// TODO: Re-add JSON and TSV commands in the future
-	//ExtractCmd.AddCommand(jsonCmd)
-	//ExtractCmd.AddCommand(tsvCmd)
 	ExtractCmd.AddCommand(PostgresCmd)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,9 +17,10 @@ var keepaliveParams = keepalive.ClientParameters{
 	PermitWithoutStream: true,
 }
 
-func NewGRPCClients(ctx context.Context, address string, insecure bool) *grpc.ClientConn {
+func NewGRPCClients(ctx context.Context, address string, insecure bool, maxCallRecvMsgSize int) *grpc.ClientConn {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithKeepaliveParams(keepaliveParams))
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize)))
 	if insecure {
 		opts = append(opts, grpc.WithInsecure())
 	} else {

--- a/internal/config/extract.go
+++ b/internal/config/extract.go
@@ -15,6 +15,7 @@ type ExtractConfig struct {
 	LiveMonitoring bool
 	Insecure       bool
 	ReIndex        bool
+	MaxRecvMsgSize int
 }
 
 func (c ExtractConfig) Validate() error {
@@ -34,5 +35,6 @@ func LoadExtractConfigFromCLI() ExtractConfig {
 		LiveMonitoring: viper.GetBool("live"),
 		Insecure:       viper.GetBool("insecure"),
 		ReIndex:        viper.GetBool("reindex"),
+		MaxRecvMsgSize: viper.GetInt("max-recv-msg-size"),
 	}
 }

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -75,7 +75,7 @@ func handleInterrupt(cancel context.CancelFunc) {
 // initializeGRPC initializes the gRPC client, fetches protocol buffer descriptors & creates the PB resolver.
 func initializeGRPC(ctx context.Context, address string, cfg config.ExtractConfig) (*grpc.ClientConn, *reflection.CustomResolver, error) {
 	slog.Info("Initializing gRPC client pool...")
-	grpcConn := client.NewGRPCClients(ctx, address, cfg.Insecure)
+	grpcConn := client.NewGRPCClients(ctx, address, cfg.Insecure, cfg.MaxRecvMsgSize)
 
 	slog.Info("Fetching protocol buffer descriptors from gRPC server... This may take a while.")
 	descriptors, err := reflection.FetchAllDescriptors(ctx, grpcConn, cfg.MaxRetries)


### PR DESCRIPTION
This PR allows the user to configure the max gRPC recv. msg. size (in bytes) using a CLI parameter. The default value is 4MB.