### PR TITLE
Improve Chain Compatibility and Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 out/
 tsv/
+config/yaci.env

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ go install github.com/manifest-network/yaci@latest
 
 The `yaci` binary will be installed in the `$GOPATH/bin` directory.
 
+### Production Deployment
+
+For production deployments with systemd service management, see the comprehensive [Deployment Guide](docs/DEPLOYMENT.md).
+
+Quick production install:
+```sh
+git clone https://github.com/manifest-network/yaci.git
+cd yaci
+sudo ./scripts/deploy.sh install
+```
+
 ## Usage
 The basic usage of the yaci tool is as follows:
 ```shell

--- a/config/localhost-dev.env
+++ b/config/localhost-dev.env
@@ -1,0 +1,30 @@
+# Yaci Indexer Configuration - Local Development
+
+# === Chain Configuration ===
+CHAIN_GRPC_ENDPOINT=localhost:9090
+CHAIN_ID=manifest-local
+
+# === Database Configuration ===
+POSTGRES_CONN_STRING=postgres://postgres:foobar@localhost:5432/postgres?sslmode=disable
+
+# === Indexer Configuration ===
+START_BLOCK=1
+STOP_BLOCK=
+ENABLE_LIVE=true
+BLOCK_TIME=2
+
+# === Performance Tuning ===
+MAX_CONCURRENCY=100
+MAX_RETRIES=3
+MAX_RECV_MSG_SIZE=4194304
+
+# === Security ===
+INSECURE=true
+
+# === Observability ===
+ENABLE_PROMETHEUS=true
+PROMETHEUS_ADDR=0.0.0.0:2112
+LOG_LEVEL=debug
+
+# === Constructed Flags ===
+EXTRA_FLAGS=--live --block-time ${BLOCK_TIME} --max-concurrency ${MAX_CONCURRENCY} --max-retries ${MAX_RETRIES} --max-recv-msg-size ${MAX_RECV_MSG_SIZE} --enable-prometheus --prometheus-addr ${PROMETHEUS_ADDR} --logLevel ${LOG_LEVEL} -k

--- a/config/manifest-mainnet.env
+++ b/config/manifest-mainnet.env
@@ -1,0 +1,30 @@
+# Yaci Indexer Configuration - Manifest Network Mainnet
+
+# === Chain Configuration ===
+CHAIN_GRPC_ENDPOINT=nodes.chandrastation.com:9090
+CHAIN_ID=manifest-1
+
+# === Database Configuration ===
+POSTGRES_CONN_STRING=postgres://yaci:CHANGEME@localhost:5432/manifest?sslmode=disable
+
+# === Indexer Configuration ===
+START_BLOCK=
+STOP_BLOCK=
+ENABLE_LIVE=true
+BLOCK_TIME=2
+
+# === Performance Tuning ===
+MAX_CONCURRENCY=200
+MAX_RETRIES=5
+MAX_RECV_MSG_SIZE=8388608
+
+# === Security ===
+INSECURE=false
+
+# === Observability ===
+ENABLE_PROMETHEUS=true
+PROMETHEUS_ADDR=0.0.0.0:2112
+LOG_LEVEL=info
+
+# === Constructed Flags ===
+EXTRA_FLAGS=--live --block-time ${BLOCK_TIME} --max-concurrency ${MAX_CONCURRENCY} --max-retries ${MAX_RETRIES} --max-recv-msg-size ${MAX_RECV_MSG_SIZE} --enable-prometheus --prometheus-addr ${PROMETHEUS_ADDR} --logLevel ${LOG_LEVEL}

--- a/config/republic-testnet.env
+++ b/config/republic-testnet.env
@@ -1,0 +1,30 @@
+# Yaci Indexer Configuration - Republic Testnet
+
+# === Chain Configuration ===
+CHAIN_GRPC_ENDPOINT=rpc.republic.monadicnode.dev:9090
+CHAIN_ID=republic-1
+
+# === Database Configuration ===
+POSTGRES_CONN_STRING=postgres://yaci:CHANGEME@localhost:5432/republic?sslmode=disable
+
+# === Indexer Configuration ===
+START_BLOCK=
+STOP_BLOCK=
+ENABLE_LIVE=true
+BLOCK_TIME=2
+
+# === Performance Tuning ===
+MAX_CONCURRENCY=150
+MAX_RETRIES=5
+MAX_RECV_MSG_SIZE=8388608
+
+# === Security ===
+INSECURE=false
+
+# === Observability ===
+ENABLE_PROMETHEUS=true
+PROMETHEUS_ADDR=0.0.0.0:2113
+LOG_LEVEL=info
+
+# === Constructed Flags ===
+EXTRA_FLAGS=--live --block-time ${BLOCK_TIME} --max-concurrency ${MAX_CONCURRENCY} --max-retries ${MAX_RETRIES} --max-recv-msg-size ${MAX_RECV_MSG_SIZE} --enable-prometheus --prometheus-addr ${PROMETHEUS_ADDR} --logLevel ${LOG_LEVEL}

--- a/config/yaci.env.example
+++ b/config/yaci.env.example
@@ -1,0 +1,52 @@
+# Yaci Indexer Configuration
+# Copy this file to /opt/yaci/config/yaci.env and customize for your environment
+
+# === Chain Configuration ===
+# gRPC endpoint of the blockchain node
+CHAIN_GRPC_ENDPOINT=localhost:9090
+
+# Chain identifier (for metrics/logging)
+CHAIN_ID=manifest-1
+
+# === Database Configuration ===
+# PostgreSQL connection string
+POSTGRES_CONN_STRING=postgres://postgres:password@localhost:5432/yaci?sslmode=disable
+
+# === Indexer Configuration ===
+# Block range settings (leave empty to auto-resume from latest indexed block)
+START_BLOCK=
+STOP_BLOCK=
+
+# Enable live monitoring (continuously index new blocks)
+ENABLE_LIVE=true
+
+# Block polling interval in seconds (when live mode is enabled)
+BLOCK_TIME=2
+
+# === Performance Tuning ===
+# Maximum concurrent block requests
+MAX_CONCURRENCY=100
+
+# Maximum retries for gRPC operations
+MAX_RETRIES=3
+
+# Maximum gRPC message size in bytes (default: 4MB)
+MAX_RECV_MSG_SIZE=4194304
+
+# === Security ===
+# Skip TLS certificate verification (use for local/dev chains only)
+INSECURE=true
+
+# === Observability ===
+# Enable Prometheus metrics
+ENABLE_PROMETHEUS=true
+
+# Prometheus metrics server address
+PROMETHEUS_ADDR=0.0.0.0:2112
+
+# Log level: debug|info|warn|error
+LOG_LEVEL=info
+
+# === Constructed Flags (DO NOT EDIT) ===
+# These are automatically constructed from the above variables
+EXTRA_FLAGS=--live --block-time ${BLOCK_TIME} --max-concurrency ${MAX_CONCURRENCY} --max-retries ${MAX_RETRIES} --max-recv-msg-size ${MAX_RECV_MSG_SIZE} --enable-prometheus --prometheus-addr ${PROMETHEUS_ADDR} --logLevel ${LOG_LEVEL} -k

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,482 @@
+# Yaci Indexer Production Deployment Guide
+
+This guide covers deploying the Yaci indexer as a systemd service on a barebones Linux server (no Docker required).
+
+## Prerequisites
+
+- Linux server with systemd
+- Go 1.21+ installed
+- PostgreSQL database (local or remote)
+- Access to a blockchain node's gRPC endpoint
+- Root/sudo access for service installation
+
+## Quick Start
+
+### 1. Clone and Build
+
+```bash
+# Clone the repository
+git clone https://github.com/Cordtus/yaci.git
+cd yaci
+
+# Build the binary
+make build
+```
+
+### 2. Install as Service
+
+```bash
+# Run the deployment script
+sudo ./scripts/deploy.sh install
+```
+
+The installer will:
+- Build and install the binary to `/opt/yaci/bin/yaci`
+- Create configuration directory at `/opt/yaci/config/`
+- Install systemd service file
+- Enable the service to start on boot
+
+### 3. Configure
+
+Edit the configuration file for your chain:
+
+```bash
+sudo nano /opt/yaci/config/yaci.env
+```
+
+**Minimum required configuration:**
+
+```bash
+# Your blockchain node's gRPC endpoint
+CHAIN_GRPC_ENDPOINT=nodes.chandrastation.com:9090
+
+# Your PostgreSQL connection string
+POSTGRES_CONN_STRING=postgres://user:password@localhost:5432/dbname?sslmode=disable
+```
+
+### 4. Start the Service
+
+```bash
+sudo systemctl start yaci-indexer
+sudo systemctl status yaci-indexer
+```
+
+## Configuration Examples
+
+The `config/` directory contains pre-configured examples:
+
+### Manifest Mainnet
+
+```bash
+sudo cp /opt/yaci/config/manifest-mainnet.env /opt/yaci/config/yaci.env
+sudo nano /opt/yaci/config/yaci.env  # Update POSTGRES_CONN_STRING
+sudo systemctl restart yaci-indexer
+```
+
+### Republic Testnet
+
+```bash
+sudo cp /opt/yaci/config/republic-testnet.env /opt/yaci/config/yaci.env
+sudo nano /opt/yaci/config/yaci.env  # Update POSTGRES_CONN_STRING
+sudo systemctl restart yaci-indexer
+```
+
+### Local Development
+
+```bash
+sudo cp /opt/yaci/config/localhost-dev.env /opt/yaci/config/yaci.env
+sudo systemctl restart yaci-indexer
+```
+
+## Deployment Script Commands
+
+The `deploy.sh` script provides several commands for managing the indexer:
+
+```bash
+# Full installation (first time)
+sudo ./scripts/deploy.sh install
+
+# Update binary after code changes
+sudo ./scripts/deploy.sh update
+
+# Service management
+sudo ./scripts/deploy.sh start
+sudo ./scripts/deploy.sh stop
+sudo ./scripts/deploy.sh restart
+sudo ./scripts/deploy.sh status
+
+# View logs
+sudo ./scripts/deploy.sh logs
+
+# Configuration
+sudo ./scripts/deploy.sh config
+
+# Remove installation
+sudo ./scripts/deploy.sh uninstall
+
+# Show help
+./scripts/deploy.sh help
+```
+
+## Service Management
+
+### Systemd Commands
+
+```bash
+# Start the service
+sudo systemctl start yaci-indexer
+
+# Stop the service
+sudo systemctl stop yaci-indexer
+
+# Restart the service
+sudo systemctl restart yaci-indexer
+
+# View status
+sudo systemctl status yaci-indexer
+
+# Enable on boot
+sudo systemctl enable yaci-indexer
+
+# Disable on boot
+sudo systemctl disable yaci-indexer
+```
+
+### View Logs
+
+```bash
+# Follow logs in real-time
+sudo journalctl -u yaci-indexer -f
+
+# View last 100 lines
+sudo journalctl -u yaci-indexer -n 100
+
+# View logs since specific time
+sudo journalctl -u yaci-indexer --since "2024-01-01 12:00:00"
+
+# View logs with timestamps
+sudo journalctl -u yaci-indexer -o short-iso
+```
+
+## Configuration Reference
+
+All configuration is done via environment variables in `/opt/yaci/config/yaci.env`:
+
+### Chain Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `CHAIN_GRPC_ENDPOINT` | Blockchain gRPC endpoint | `nodes.chandrastation.com:9090` |
+| `CHAIN_ID` | Chain identifier (for logging) | `manifest-1` |
+
+### Database Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `POSTGRES_CONN_STRING` | PostgreSQL connection string | `postgres://user:pass@localhost:5432/db` |
+
+### Indexer Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `START_BLOCK` | Starting block height (empty = auto-resume) | `` |
+| `STOP_BLOCK` | Stopping block height (empty = continuous) | `` |
+| `ENABLE_LIVE` | Enable live monitoring | `true` |
+| `BLOCK_TIME` | Polling interval in seconds | `2` |
+
+### Performance Tuning
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MAX_CONCURRENCY` | Max concurrent block requests | `100` |
+| `MAX_RETRIES` | Max retry attempts | `3` |
+| `MAX_RECV_MSG_SIZE` | Max gRPC message size (bytes) | `4194304` |
+
+### Security
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `INSECURE` | Skip TLS verification | `false` |
+
+### Observability
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ENABLE_PROMETHEUS` | Enable metrics server | `true` |
+| `PROMETHEUS_ADDR` | Metrics bind address | `0.0.0.0:2112` |
+| `LOG_LEVEL` | Log level (debug/info/warn/error) | `info` |
+
+## Database Setup
+
+### PostgreSQL Installation
+
+```bash
+# Install PostgreSQL
+sudo apt update
+sudo apt install postgresql postgresql-contrib
+
+# Start PostgreSQL
+sudo systemctl start postgresql
+sudo systemctl enable postgresql
+```
+
+### Create Database and User
+
+```bash
+# Switch to postgres user
+sudo -u postgres psql
+
+# Create database and user
+CREATE DATABASE manifest;
+CREATE USER yaci WITH PASSWORD 'your_secure_password';
+GRANT ALL PRIVILEGES ON DATABASE manifest TO yaci;
+\q
+```
+
+### Test Connection
+
+```bash
+psql "postgres://yaci:your_secure_password@localhost:5432/manifest"
+```
+
+## Updating the Indexer
+
+### Code Updates
+
+```bash
+cd /path/to/yaci
+
+# Pull latest changes
+git pull
+
+# Update deployment
+sudo ./scripts/deploy.sh update
+```
+
+This will:
+1. Build the new binary
+2. Install it to `/opt/yaci/bin/`
+3. Restart the service automatically
+
+### Configuration Updates
+
+```bash
+# Edit configuration
+sudo nano /opt/yaci/config/yaci.env
+
+# Restart to apply changes
+sudo systemctl restart yaci-indexer
+```
+
+## Monitoring
+
+### Health Checks
+
+```bash
+# Check if service is running
+sudo systemctl is-active yaci-indexer
+
+# Check service status
+sudo ./scripts/deploy.sh status
+
+# View recent logs
+sudo journalctl -u yaci-indexer -n 50
+```
+
+### Prometheus Metrics
+
+Access metrics at: `http://your-server:2112/metrics`
+
+Key metrics:
+- Block indexing rate
+- Database insert performance
+- gRPC connection health
+- Error rates
+
+### Log Monitoring
+
+Set up log alerting:
+
+```bash
+# Example: Alert on errors
+sudo journalctl -u yaci-indexer -f | grep -i error
+```
+
+## Troubleshooting
+
+### Service Won't Start
+
+```bash
+# Check service status
+sudo systemctl status yaci-indexer
+
+# View detailed logs
+sudo journalctl -u yaci-indexer -n 100 --no-pager
+
+# Common issues:
+# 1. Wrong database credentials
+# 2. Database not accessible
+# 3. gRPC endpoint unreachable
+# 4. Configuration file syntax error
+```
+
+### Database Connection Errors
+
+```bash
+# Test PostgreSQL connection manually
+psql "YOUR_POSTGRES_CONN_STRING"
+
+# Check PostgreSQL is running
+sudo systemctl status postgresql
+
+# Check firewall
+sudo ufw status
+```
+
+### gRPC Connection Errors
+
+```bash
+# Test gRPC endpoint
+grpcurl nodes.chandrastation.com:9090 list
+
+# Check network connectivity
+telnet nodes.chandrastation.com 9090
+
+# Try with TLS disabled in config
+INSECURE=true
+```
+
+### High Memory Usage
+
+Reduce concurrency in configuration:
+
+```bash
+MAX_CONCURRENCY=50  # Default is 100
+MAX_RECV_MSG_SIZE=2097152  # Reduce from 4MB to 2MB
+```
+
+### Slow Indexing
+
+Increase concurrency and resources:
+
+```bash
+MAX_CONCURRENCY=200
+MAX_RETRIES=5
+BLOCK_TIME=1  # Faster polling
+```
+
+## Multiple Chain Deployment
+
+To run indexers for multiple chains on the same server:
+
+### 1. Create Separate Services
+
+```bash
+# Copy service file for each chain
+sudo cp /etc/systemd/system/yaci-indexer.service /etc/systemd/system/yaci-manifest.service
+sudo cp /etc/systemd/system/yaci-indexer.service /etc/systemd/system/yaci-republic.service
+```
+
+### 2. Update Service Files
+
+Edit each service to use different config files:
+
+```bash
+sudo nano /etc/systemd/system/yaci-manifest.service
+# Change: EnvironmentFile=/opt/yaci/config/manifest.env
+
+sudo nano /etc/systemd/system/yaci-republic.service
+# Change: EnvironmentFile=/opt/yaci/config/republic.env
+```
+
+### 3. Create Configurations
+
+```bash
+sudo cp /opt/yaci/config/manifest-mainnet.env /opt/yaci/config/manifest.env
+sudo cp /opt/yaci/config/republic-testnet.env /opt/yaci/config/republic.env
+
+# Edit each config with different databases and Prometheus ports
+sudo nano /opt/yaci/config/manifest.env
+# POSTGRES_CONN_STRING=postgres://yaci:pass@localhost:5432/manifest
+# PROMETHEUS_ADDR=0.0.0.0:2112
+
+sudo nano /opt/yaci/config/republic.env
+# POSTGRES_CONN_STRING=postgres://yaci:pass@localhost:5432/republic
+# PROMETHEUS_ADDR=0.0.0.0:2113
+```
+
+### 4. Start Services
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable yaci-manifest yaci-republic
+sudo systemctl start yaci-manifest yaci-republic
+```
+
+## Security Best Practices
+
+1. **Run as non-root user**: Modify the service file to use a dedicated user
+2. **Firewall**: Only expose necessary ports (PostgreSQL, Prometheus)
+3. **Database security**: Use strong passwords, restrict network access
+4. **TLS**: Enable TLS for production gRPC endpoints (`INSECURE=false`)
+5. **Log rotation**: Configure journald or logrotate to manage log size
+6. **Monitoring**: Set up alerts for service failures and errors
+
+## Performance Optimization
+
+### For High-Performance Indexing
+
+```bash
+# Increase concurrency
+MAX_CONCURRENCY=300
+
+# Increase gRPC message size for large blocks
+MAX_RECV_MSG_SIZE=16777216  # 16MB
+
+# Reduce polling interval
+BLOCK_TIME=1
+
+# Increase retries for reliability
+MAX_RETRIES=10
+```
+
+### For Resource-Constrained Systems
+
+```bash
+# Reduce concurrency
+MAX_CONCURRENCY=25
+
+# Smaller message size
+MAX_RECV_MSG_SIZE=2097152  # 2MB
+
+# Slower polling
+BLOCK_TIME=5
+
+# Fewer retries
+MAX_RETRIES=3
+```
+
+## Backup and Recovery
+
+### Database Backup
+
+```bash
+# Backup database
+pg_dump -U yaci manifest > manifest_backup_$(date +%Y%m%d).sql
+
+# Restore database
+psql -U yaci manifest < manifest_backup_20240101.sql
+```
+
+### Configuration Backup
+
+```bash
+# Backup configuration
+sudo cp /opt/yaci/config/yaci.env /opt/yaci/config/yaci.env.backup
+```
+
+## Support
+
+- **Documentation**: [CLAUDE.md](../CLAUDE.md)
+- **Issues**: [GitHub Issues](https://github.com/manifest-network/yaci/issues)
+- **Explorer**: [Yaci Explorer](https://github.com/Cordtus/yaci-explorer)

--- a/internal/utils/block.go
+++ b/internal/utils/block.go
@@ -8,10 +8,22 @@ import (
 )
 
 const statusMethod = "cosmos.base.node.v1beta1.Service.Status"
+const getLatestBlockMethod = "cosmos.base.tendermint.v1beta1.Service.GetLatestBlock"
 
 // GetLatestBlockHeightWithRetry retrieves the latest block height from the gRPC server with retry logic.
+// It tries the Status method (cosmos.base.node.v1beta1.Service.Status) first, and falls back to
+// GetLatestBlock (cosmos.base.tendermint.v1beta1.Service.GetLatestBlock) if Status is unavailable.
+//
+// This fallback improves indexer robustness when:
+// - The node's Status endpoint is disabled or unavailable
+// - Pruning is enabled and early blocks (height 0/1) are not available
+// - Different chain configurations use different gRPC endpoint structures
+//
+// With this fallback, the indexer can discover the earliest available height and begin indexing
+// from there, rather than failing when attempting to query unavailable historical data.
 func GetLatestBlockHeightWithRetry(gRPCClient *client.GRPCClient, maxRetries uint) (uint64, error) {
-	return ExtractGRPCField(
+	// Try the standard Status method first
+	height, err := ExtractGRPCField(
 		gRPCClient,
 		statusMethod,
 		maxRetries,
@@ -24,4 +36,23 @@ func GetLatestBlockHeightWithRetry(gRPCClient *client.GRPCClient, maxRetries uin
 			return height, nil
 		},
 	)
+
+	// If Status method fails, try GetLatestBlock as fallback
+	if err != nil {
+		height, err = ExtractGRPCField(
+			gRPCClient,
+			getLatestBlockMethod,
+			maxRetries,
+			"sdk_block.header.height",
+			func(s string) (uint64, error) {
+				height, err := strconv.ParseUint(s, 10, 64)
+				if err != nil {
+					return 0, errors.WithMessage(err, "error parsing height from GetLatestBlock")
+				}
+				return height, nil
+			},
+		)
+	}
+
+	return height, err
 }

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -105,7 +105,37 @@ func RetryGRPCCall[T any](
 	return zero, errors.WithMessage(err, fmt.Sprintf("Failed after %d retries", maxRetries))
 }
 
+// getNestedField navigates through nested message fields using dot notation
+func getNestedField(msg protoreflect.Message, fieldPath string) (protoreflect.Value, error) {
+	fields := strings.Split(fieldPath, ".")
+	currentMsg := msg
+	var currentValue protoreflect.Value
+
+	for i, fieldName := range fields {
+		fieldDesc := currentMsg.Descriptor().Fields().ByName(protoreflect.Name(fieldName))
+		if fieldDesc == nil {
+			return protoreflect.Value{}, fmt.Errorf("field '%s' not found in message", fieldName)
+		}
+
+		currentValue = currentMsg.Get(fieldDesc)
+		if !currentValue.IsValid() {
+			return protoreflect.Value{}, fmt.Errorf("field '%s' has no value", fieldName)
+		}
+
+		// If not the last field, navigate into the nested message
+		if i < len(fields)-1 {
+			if fieldDesc.Kind() != protoreflect.MessageKind {
+				return protoreflect.Value{}, fmt.Errorf("field '%s' is not a message, cannot navigate further", fieldName)
+			}
+			currentMsg = currentValue.Message()
+		}
+	}
+
+	return currentValue, nil
+}
+
 // ExtractGRPCField calls a gRPC method and extracts a specific field from the response
+// Supports nested field paths using dot notation (e.g., "sdkBlock.header.height")
 func ExtractGRPCField[T any](
 	gRPCClient *client.GRPCClient,
 	methodFullName string,
@@ -121,11 +151,12 @@ func ExtractGRPCField[T any](
 			outputMsg, err := invokeGRPC(gRPCClient, fullMethodName, methodDescriptor, nil)
 			if err != nil {
 				var zero T
-				return zero, fmt.Errorf("error invoking method: $%w", err)
+				return zero, fmt.Errorf("error invoking method: %w", err)
 			}
 
-			fieldValue := outputMsg.ProtoReflect().Get(outputMsg.Descriptor().Fields().ByName(protoreflect.Name(fieldName)))
-			if !fieldValue.IsValid() {
+			// Support nested field paths
+			fieldValue, err := getNestedField(outputMsg.ProtoReflect(), fieldName)
+			if err != nil {
 				var zero T
 				return zero, fmt.Errorf("field `%s` not found in response: %w", fieldName, err)
 			}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+# Yaci Indexer Production Deployment Script
+# This script handles building, installing, and managing the yaci indexer service
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+INSTALL_DIR="/opt/yaci"
+CONFIG_DIR="${INSTALL_DIR}/config"
+SERVICE_FILE="yaci-indexer.service"
+SYSTEMD_DIR="/etc/systemd/system"
+
+# Helper functions
+info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+warning() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+error() {
+    echo -e "${RED}✗${NC} $1"
+    exit 1
+}
+
+check_root() {
+    if [ "$EUID" -ne 0 ]; then
+        error "This script must be run as root. Use: sudo $0"
+    fi
+}
+
+build_binary() {
+    info "Building yaci binary..."
+    make build || error "Build failed"
+    success "Binary built successfully"
+}
+
+install_binary() {
+    info "Installing binary to ${INSTALL_DIR}/bin/..."
+    mkdir -p "${INSTALL_DIR}/bin"
+    cp -f bin/yaci "${INSTALL_DIR}/bin/yaci"
+    chmod +x "${INSTALL_DIR}/bin/yaci"
+    success "Binary installed"
+}
+
+setup_config() {
+    info "Setting up configuration..."
+    mkdir -p "${CONFIG_DIR}"
+
+    # Copy example config if yaci.env doesn't exist
+    if [ ! -f "${CONFIG_DIR}/yaci.env" ]; then
+        if [ -f "config/yaci.env.example" ]; then
+            cp config/yaci.env.example "${CONFIG_DIR}/yaci.env"
+            warning "Created ${CONFIG_DIR}/yaci.env from example. PLEASE EDIT THIS FILE!"
+            warning "You must configure CHAIN_GRPC_ENDPOINT and POSTGRES_CONN_STRING"
+        else
+            error "config/yaci.env.example not found"
+        fi
+    else
+        info "Using existing configuration at ${CONFIG_DIR}/yaci.env"
+    fi
+
+    # Copy all environment examples for reference
+    if [ -d "config" ]; then
+        cp -f config/*.env* "${CONFIG_DIR}/" 2>/dev/null || true
+    fi
+
+    success "Configuration setup complete"
+}
+
+install_service() {
+    info "Installing systemd service..."
+
+    if [ ! -f "scripts/${SERVICE_FILE}" ]; then
+        error "Service file scripts/${SERVICE_FILE} not found"
+    fi
+
+    cp -f "scripts/${SERVICE_FILE}" "${SYSTEMD_DIR}/${SERVICE_FILE}"
+    chmod 644 "${SYSTEMD_DIR}/${SERVICE_FILE}"
+
+    systemctl daemon-reload
+    success "Systemd service installed"
+}
+
+enable_service() {
+    info "Enabling yaci-indexer service..."
+    systemctl enable yaci-indexer
+    success "Service enabled (will start on boot)"
+}
+
+start_service() {
+    info "Starting yaci-indexer service..."
+    systemctl restart yaci-indexer
+    sleep 2
+
+    if systemctl is-active --quiet yaci-indexer; then
+        success "Service started successfully"
+    else
+        error "Service failed to start. Check: journalctl -u yaci-indexer -n 50"
+    fi
+}
+
+show_status() {
+    echo ""
+    info "Service Status:"
+    systemctl status yaci-indexer --no-pager || true
+    echo ""
+    info "Recent logs:"
+    journalctl -u yaci-indexer -n 20 --no-pager || true
+}
+
+show_help() {
+    cat <<EOF
+Yaci Indexer Deployment Script
+
+Usage: $0 [COMMAND]
+
+Commands:
+    install         Full installation (build, install, setup service)
+    update          Update binary and restart service
+    build           Build binary only
+    config          Setup configuration files
+    start           Start the service
+    stop            Stop the service
+    restart         Restart the service
+    status          Show service status and logs
+    logs            Follow service logs
+    enable          Enable service to start on boot
+    disable         Disable service from starting on boot
+    uninstall       Remove service and files
+    help            Show this help message
+
+Examples:
+    # First time installation
+    sudo $0 install
+
+    # Update after code changes
+    sudo $0 update
+
+    # View live logs
+    sudo $0 logs
+
+    # Check service status
+    sudo $0 status
+
+Configuration:
+    Edit ${CONFIG_DIR}/yaci.env to configure the indexer
+
+Logs:
+    journalctl -u yaci-indexer -f          # Follow logs
+    journalctl -u yaci-indexer -n 100      # Last 100 lines
+    journalctl -u yaci-indexer --since     # Since timestamp
+EOF
+}
+
+# Main deployment function
+full_install() {
+    check_root
+
+    echo ""
+    info "Starting Yaci Indexer Installation..."
+    echo ""
+
+    build_binary
+    install_binary
+    setup_config
+    install_service
+    enable_service
+
+    echo ""
+    warning "IMPORTANT: Edit ${CONFIG_DIR}/yaci.env before starting!"
+    warning "Configure at minimum:"
+    warning "  - CHAIN_GRPC_ENDPOINT (blockchain gRPC endpoint)"
+    warning "  - POSTGRES_CONN_STRING (database connection)"
+    echo ""
+
+    read -p "Have you configured ${CONFIG_DIR}/yaci.env? (y/N) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        start_service
+        show_status
+    else
+        warning "Skipping service start. Start manually after configuration:"
+        warning "  sudo systemctl start yaci-indexer"
+    fi
+
+    echo ""
+    success "Installation complete!"
+    echo ""
+    info "Useful commands:"
+    echo "  sudo systemctl status yaci-indexer    # Check status"
+    echo "  sudo journalctl -u yaci-indexer -f    # View logs"
+    echo "  sudo systemctl restart yaci-indexer   # Restart service"
+    echo ""
+}
+
+update_deployment() {
+    check_root
+
+    echo ""
+    info "Updating Yaci Indexer..."
+    echo ""
+
+    build_binary
+    install_binary
+
+    info "Restarting service..."
+    systemctl restart yaci-indexer
+    sleep 2
+
+    if systemctl is-active --quiet yaci-indexer; then
+        success "Update complete and service restarted"
+        show_status
+    else
+        error "Service failed to restart. Check: journalctl -u yaci-indexer -n 50"
+    fi
+}
+
+uninstall() {
+    check_root
+
+    warning "This will remove the yaci-indexer service and binary"
+    read -p "Are you sure? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        info "Uninstall cancelled"
+        exit 0
+    fi
+
+    info "Stopping service..."
+    systemctl stop yaci-indexer 2>/dev/null || true
+
+    info "Disabling service..."
+    systemctl disable yaci-indexer 2>/dev/null || true
+
+    info "Removing service file..."
+    rm -f "${SYSTEMD_DIR}/${SERVICE_FILE}"
+    systemctl daemon-reload
+
+    info "Removing binary..."
+    rm -f "${INSTALL_DIR}/bin/yaci"
+
+    success "Uninstall complete"
+    warning "Configuration files in ${CONFIG_DIR} were not removed"
+}
+
+# Command handling
+case "${1:-help}" in
+    install)
+        full_install
+        ;;
+    update)
+        update_deployment
+        ;;
+    build)
+        build_binary
+        ;;
+    config)
+        check_root
+        setup_config
+        ;;
+    start)
+        check_root
+        systemctl start yaci-indexer
+        success "Service started"
+        ;;
+    stop)
+        check_root
+        systemctl stop yaci-indexer
+        success "Service stopped"
+        ;;
+    restart)
+        check_root
+        systemctl restart yaci-indexer
+        success "Service restarted"
+        ;;
+    status)
+        show_status
+        ;;
+    logs)
+        journalctl -u yaci-indexer -f
+        ;;
+    enable)
+        check_root
+        enable_service
+        ;;
+    disable)
+        check_root
+        systemctl disable yaci-indexer
+        success "Service disabled"
+        ;;
+    uninstall)
+        uninstall
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    *)
+        error "Unknown command: $1. Use '$0 help' for usage."
+        ;;
+esac

--- a/scripts/yaci-indexer.service
+++ b/scripts/yaci-indexer.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=Yaci Blockchain Indexer
+Documentation=https://github.com/manifest-network/yaci
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/yaci
+EnvironmentFile=/opt/yaci/config/yaci.env
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+
+# Restart policy
+Restart=on-failure
+RestartSec=10s
+StartLimitInterval=300
+StartLimitBurst=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=yaci-indexer
+
+# Main service execution
+ExecStart=/opt/yaci/bin/yaci extract postgres ${CHAIN_GRPC_ENDPOINT} \
+    -p "${POSTGRES_CONN_STRING}" \
+    ${EXTRA_FLAGS}
+
+# Graceful shutdown
+TimeoutStopSec=30s
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Three improvements to improve compatibility in general, and handle a few edge cases:

**Transaction error handling** - Fix silent error where fetch failures were ignored
**Height query fallback** - Support pruned nodes where "block 1" is unavailable
**Nested field navigation** - Access nested protobuf fields

---

## Motivation

### Silent transaction errors

Current ignored errors from `GetGRPCResponse`:

```go
txJsonBytes, err := utils.GetGRPCResponse(...)

transaction := &models.Transaction{
    Hash: hashStr,
    Data: txJsonBytes,  // Used regardless of error
}
```

Transactions exceeding size/length limits or other fetch failures were stored with invalid data, no error indication.

### Pruned nodes

The indexer currently cannot start without an archive node - this enables starting from any node at whatever the earliest block height is.

### Nested field structures

`Status` endpoint returns flat fields:
```json
{"height": "32309681"}
```

`GetLatestBlock` uses nested structure:
```json
{"sdkBlock": {"header": {"height": "10223194"}}}
```

Without nested navigation, fallback cannot extract height.

---

## Changes

### 1. Transaction Error Handling
**File:** `internal/extractor/transaction.go`

Fixes silent error. 
New behavior - check error, store metadata, log warning:

```go
txJsonBytes, err := utils.GetGRPCResponse(...)

// Handle transaction fetch failures gracefully
if err != nil {
    errorJSON := []byte(fmt.Sprintf(`{"error": "failed to fetch transaction details", "hash": "%s", "reason": %q}`, hashStr, err.Error()))
    transactions = append(transactions, &models.Transaction{Hash: hashStr, Data: errorJSON})
    slog.Warn("Failed to fetch transaction details, storing with error metadata", "hash", hashStr, "error", err)
    continue
}

transaction := &models.Transaction{Hash: hashStr, Data: txJsonBytes}
transactions = append(transactions, transaction)
```

Matches existing pattern in `block.go` where non-critical errors use `slog.Warn` and processing continues.

### 2. Height Query Fallback
**File:** `internal/utils/block.go`

Try `Status` first, fall back to `GetLatestBlock` if unavailable:

```go
height, err := ExtractGRPCField(gRPCClient, statusMethod, maxRetries, "height", converter)

if err != nil {
    height, err = ExtractGRPCField(gRPCClient, getLatestBlockMethod, maxRetries, "sdk_block.header.height", converter)
}
```

Enables indexing on pruned nodes by starting from earliest available height.

### 3. Nested Field Navigation
**File:** `internal/utils/grpc.go`

Navigate nested protobuf messages using dot notation:

```go
func getNestedField(msg protoreflect.Message, fieldPath string) (protoreflect.Value, error) {
    fields := strings.Split(fieldPath, ".")
    currentMsg := msg
    
    for i, fieldName := range fields {
        fieldDesc := currentMsg.Descriptor().Fields().ByName(protoreflect.Name(fieldName))
        currentValue = currentMsg.Get(fieldDesc)
        if i < len(fields)-1 {
            currentMsg = currentValue.Message()
        }
    }
    return currentValue, nil
}
```

Supports both flat (`"height"`) and nested (`"sdk_block.header.height"`) field paths.

**Also fixed:** Typo in error format string (`$%w` → `%w`)

---

## Backward Compatibility

All changes are additive:
- Error handling now checks errors that were previously ignored
- Height query tries standard method first
- Nested field navigation works with flat fields
