### PR TITLE
Improve Chain Compatibility and Error Handling

### DIFF
--- a/internal/utils/block.go
+++ b/internal/utils/block.go
@@ -1,15 +1,19 @@
 package utils
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/manifest-network/yaci/internal/client"
 	"github.com/pkg/errors"
 )
 
 const statusMethod = "cosmos.base.node.v1beta1.Service.Status"
+const getBlockByHeightMethod = "cosmos.base.tendermint.v1beta1.Service.GetBlockByHeight"
 
-// GetLatestBlockHeightWithRetry retrieves the latest block height from the gRPC server with retry logic.
+// GetLatestBlockHeightWithRetry gets current block height from Status endpoint
 func GetLatestBlockHeightWithRetry(gRPCClient *client.GRPCClient, maxRetries uint) (uint64, error) {
 	return ExtractGRPCField(
 		gRPCClient,
@@ -24,4 +28,45 @@ func GetLatestBlockHeightWithRetry(gRPCClient *client.GRPCClient, maxRetries uin
 			return height, nil
 		},
 	)
+}
+
+// GetEarliestBlockHeight determines earliest available block on node.
+// Returns 1 for archive nodes, or parses error message for pruned nodes.
+func GetEarliestBlockHeight(gRPCClient *client.GRPCClient, maxRetries uint) (uint64, error) {
+	inputParams := []byte(`{"height":"1"}`)
+	_, err := GetGRPCResponse(gRPCClient, getBlockByHeightMethod, 1, inputParams)
+
+	// Block 1 exists - archive node with full history
+	if err == nil {
+		return 1, nil
+	}
+
+	// Extract lowest height from error: "height 1 is not available, lowest height is 28566001"
+	lowestHeight := parseLowestHeightFromError(err.Error())
+	if lowestHeight > 0 {
+		return lowestHeight, nil
+	}
+
+	// Retry with full retries if error was transient
+	_, err = GetGRPCResponse(gRPCClient, getBlockByHeightMethod, maxRetries, inputParams)
+	if err == nil {
+		return 1, nil
+	}
+
+	return 0, fmt.Errorf("failed to determine earliest block height: %w", err)
+}
+
+// parseLowestHeightFromError extracts lowest height from pruned node errors
+func parseLowestHeightFromError(errMsg string) uint64 {
+	re := regexp.MustCompile(`lowest height is (\d+)`)
+	matches := re.FindStringSubmatch(strings.ToLower(errMsg))
+
+	if len(matches) >= 2 {
+		height, err := strconv.ParseUint(matches[1], 10, 64)
+		if err == nil {
+			return height
+		}
+	}
+
+	return 0
 }

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -105,7 +105,37 @@ func RetryGRPCCall[T any](
 	return zero, errors.WithMessage(err, fmt.Sprintf("Failed after %d retries", maxRetries))
 }
 
+// getNestedField navigates through nested message fields using dot notation
+func getNestedField(msg protoreflect.Message, fieldPath string) (protoreflect.Value, error) {
+	fields := strings.Split(fieldPath, ".")
+	currentMsg := msg
+	var currentValue protoreflect.Value
+
+	for i, fieldName := range fields {
+		fieldDesc := currentMsg.Descriptor().Fields().ByName(protoreflect.Name(fieldName))
+		if fieldDesc == nil {
+			return protoreflect.Value{}, fmt.Errorf("field '%s' not found in message", fieldName)
+		}
+
+		currentValue = currentMsg.Get(fieldDesc)
+		if !currentValue.IsValid() {
+			return protoreflect.Value{}, fmt.Errorf("field '%s' has no value", fieldName)
+		}
+
+		// If not the last field, navigate into the nested message
+		if i < len(fields)-1 {
+			if fieldDesc.Kind() != protoreflect.MessageKind {
+				return protoreflect.Value{}, fmt.Errorf("field '%s' is not a message, cannot navigate further", fieldName)
+			}
+			currentMsg = currentValue.Message()
+		}
+	}
+
+	return currentValue, nil
+}
+
 // ExtractGRPCField calls a gRPC method and extracts a specific field from the response
+// Supports nested field paths using dot notation (e.g., "sdkBlock.header.height")
 func ExtractGRPCField[T any](
 	gRPCClient *client.GRPCClient,
 	methodFullName string,
@@ -121,11 +151,12 @@ func ExtractGRPCField[T any](
 			outputMsg, err := invokeGRPC(gRPCClient, fullMethodName, methodDescriptor, nil)
 			if err != nil {
 				var zero T
-				return zero, fmt.Errorf("error invoking method: $%w", err)
+				return zero, fmt.Errorf("error invoking method: %w", err)
 			}
 
-			fieldValue := outputMsg.ProtoReflect().Get(outputMsg.Descriptor().Fields().ByName(protoreflect.Name(fieldName)))
-			if !fieldValue.IsValid() {
+			// Support nested field paths
+			fieldValue, err := getNestedField(outputMsg.ProtoReflect(), fieldName)
+			if err != nil {
 				var zero T
 				return zero, fmt.Errorf("field `%s` not found in response: %w", fieldName, err)
 			}

--- a/internal/utils/grpc_test.go
+++ b/internal/utils/grpc_test.go
@@ -1,0 +1,230 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// createTestMessage creates a test protobuf message with nested structure
+// mimicking the cosmos.base.tendermint.v1beta1.GetLatestBlockResponse structure
+func createTestMessage(t *testing.T) protoreflect.Message {
+	t.Helper()
+
+	// Create nested message descriptors similar to:
+	// Response { height: string, sdk_block: Block { header: Header { height: string, chain_id: string } } }
+	headerDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Header"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   proto.String("height"),
+				Number: proto.Int32(1),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+			{
+				Name:   proto.String("chain_id"),
+				Number: proto.Int32(2),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+		},
+	}
+
+	blockDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Block"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("header"),
+				Number:   proto.Int32(1),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".test.Header"),
+			},
+		},
+	}
+
+	responseDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Response"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   proto.String("height"),
+				Number: proto.Int32(1),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+			{
+				Name:     proto.String("sdk_block"),
+				Number:   proto.Int32(2),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".test.Block"),
+			},
+		},
+	}
+
+	fileDesc := &descriptorpb.FileDescriptorProto{
+		Name:        proto.String("test.proto"),
+		Package:     proto.String("test"),
+		MessageType: []*descriptorpb.DescriptorProto{headerDesc, blockDesc, responseDesc},
+	}
+
+	fd, err := protodesc.NewFile(fileDesc, nil)
+	if err != nil {
+		t.Fatalf("failed to create file descriptor: %v", err)
+	}
+
+	// Create dynamic message and populate it
+	msgDesc := fd.Messages().ByName("Response")
+	if msgDesc == nil {
+		t.Fatal("Response message descriptor not found")
+	}
+
+	msg := dynamicpb.NewMessage(msgDesc)
+
+	// Set flat field: height = "12345"
+	heightField := msgDesc.Fields().ByName("height")
+	msg.Set(heightField, protoreflect.ValueOfString("12345"))
+
+	// Set nested fields: sdk_block.header.height = "67890"
+	sdkBlockField := msgDesc.Fields().ByName("sdk_block")
+	blockMsgDesc := sdkBlockField.Message()
+	blockMsg := dynamicpb.NewMessage(blockMsgDesc)
+
+	headerField := blockMsgDesc.Fields().ByName("header")
+	headerMsgDesc := headerField.Message()
+	headerMsg := dynamicpb.NewMessage(headerMsgDesc)
+
+	nestedHeightField := headerMsgDesc.Fields().ByName("height")
+	headerMsg.Set(nestedHeightField, protoreflect.ValueOfString("67890"))
+
+	chainIdField := headerMsgDesc.Fields().ByName("chain_id")
+	headerMsg.Set(chainIdField, protoreflect.ValueOfString("test-chain"))
+
+	blockMsg.Set(headerField, protoreflect.ValueOfMessage(headerMsg))
+	msg.Set(sdkBlockField, protoreflect.ValueOfMessage(blockMsg))
+
+	return msg
+}
+
+func TestGetNestedField(t *testing.T) {
+	msg := createTestMessage(t)
+
+	cases := []struct {
+		name      string
+		fieldPath string
+		wantValue string
+		wantErr   string
+	}{
+		{
+			name:      "flat field",
+			fieldPath: "height",
+			wantValue: "12345",
+		},
+		{
+			name:      "nested field - two levels",
+			fieldPath: "sdk_block.header",
+			wantValue: "", // Message type, check existence not value
+		},
+		{
+			name:      "nested field - three levels",
+			fieldPath: "sdk_block.header.height",
+			wantValue: "67890",
+		},
+		{
+			name:      "nested field - different leaf",
+			fieldPath: "sdk_block.header.chain_id",
+			wantValue: "test-chain",
+		},
+		{
+			name:      "non-existent field",
+			fieldPath: "nonexistent",
+			wantErr:   "field 'nonexistent' not found",
+		},
+		{
+			name:      "non-existent nested field",
+			fieldPath: "sdk_block.nonexistent",
+			wantErr:   "field 'nonexistent' not found",
+		},
+		{
+			name:      "navigate beyond non-message field",
+			fieldPath: "height.something",
+			wantErr:   "is not a message",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := getNestedField(msg, tc.fieldPath)
+			if tc.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+				if tc.wantValue != "" {
+					assert.Equal(t, tc.wantValue, val.String())
+				} else {
+					// For message types, just verify it's valid
+					assert.True(t, val.IsValid())
+				}
+			}
+		})
+	}
+}
+
+func TestParseMethodFullName(t *testing.T) {
+	cases := []struct {
+		name           string
+		methodFullName string
+		wantService    string
+		wantMethod     string
+		wantErr        string
+	}{
+		{
+			name:           "standard format",
+			methodFullName: "cosmos.tx.v1beta1.Service.GetBlockWithTxs",
+			wantService:    "cosmos.tx.v1beta1.Service",
+			wantMethod:     "GetBlockWithTxs",
+		},
+		{
+			name:           "simple format",
+			methodFullName: "service.Method",
+			wantService:    "service",
+			wantMethod:     "Method",
+		},
+		{
+			name:           "empty string",
+			methodFullName: "",
+			wantErr:        "method full name is empty",
+		},
+		{
+			name:           "no dot",
+			methodFullName: "InvalidMethod",
+			wantErr:        "no dot found",
+		},
+		{
+			name:           "empty service",
+			methodFullName: ".Method",
+			wantErr:        "invalid method full name format",
+		},
+		{
+			name:           "empty method",
+			methodFullName: "service.",
+			wantErr:        "invalid method full name format",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service, method, err := ParseMethodFullName(tc.methodFullName)
+			if tc.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantService, service)
+				assert.Equal(t, tc.wantMethod, method)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three improvements for better chain compatibility:

**Transaction error handling** - Store error metadata for failed transaction fetches  
**Pruned node support** - Parse error messages to find earliest available block  
**Nested field navigation** - Support dot notation for nested protobuf fields

---

## Motivation

### Transaction errors

Transactions exceeding gRPC size limits (e.g., Mantrachain block 9357143) cause block processing to fail entirely. Current code ignores fetch errors and stores invalid data.

### Pruned nodes

Indexer requires block 1, which doesn't exist on pruned nodes. Error message reveals actual lowest height: `"height 1 is not available, lowest height is 28566001"` but isn't parsed.

Archive nodes are expensive/rare - most RPC endpoints are pruned.

### Nested fields

Some endpoints return flat `{"height": "123"}` while others return nested `{"sdkBlock": {"header": {"height": "123"}}}`. Infrastructure for handling both improves future compatibility.

---

## Changes

### 1. Transaction Error Handling
**File:** `internal/extractor/transaction.go`

Check error before storing transaction. On failure, store metadata and continue processing block:

```go
if err != nil {
    errorJSON := []byte(fmt.Sprintf(`{"error": "...", "hash": "%s", "reason": %q}`, hashStr, err.Error()))
    transactions = append(transactions, &models.Transaction{Hash: hashStr, Data: errorJSON})
    slog.Warn("Failed to fetch transaction details, storing with error metadata", "hash", hashStr, "error", err)
    continue
}
```

### 2. Pruned Node Support  
**Files:** `internal/utils/block.go`, `internal/extractor/extractor.go`

New `GetEarliestBlockHeight()` function:
1. Try fetching block 1
2. If fails, parse error message for lowest available height
3. Fall back to retries for transient errors

Used when starting fresh DB or reindexing to find where to begin.

### 3. Nested Field Navigation
**File:** `internal/utils/grpc.go`

Added `getNestedField()` with dot notation support. Enables `ExtractGRPCField` to handle both flat and nested paths transparently.

Includes unit tests covering all navigation patterns.

---

## Backward Compatibility

All changes are additive - no breaking changes to existing functionality.