### PR TITLE
feat: improve chain compatibility and error handling

### DIFF
--- a/internal/extractor/block.go
+++ b/internal/extractor/block.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
+	"strconv"
 
 	"github.com/manifest-network/yaci/internal/client"
 	"github.com/manifest-network/yaci/internal/config"
@@ -16,46 +18,105 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// lowestHeightRegex matches pruned node error messages from CosmosSDK nodes.
+// Example: "height 60 is not available, lowest height is 28566001"
+// This pattern is used to detect when extraction starts below the pruning boundary.
+var lowestHeightRegex = regexp.MustCompile(`lowest height is (\d+)`)
+
+// ErrHeightNotAvailable signals that a requested block has been pruned.
+// It carries the lowest available height so the caller can restart extraction
+// from a valid block without user intervention.
+type ErrHeightNotAvailable struct {
+	RequestedHeight uint64
+	LowestHeight    uint64
+}
+
+func (e *ErrHeightNotAvailable) Error() string {
+	return fmt.Sprintf("height %d is not available, lowest height is %d", e.RequestedHeight, e.LowestHeight)
+}
+
+// parseLowestHeight extracts the lowest available height from a pruned node error.
+// Returns (height, true) if found, (0, false) otherwise.
+func parseLowestHeight(errMsg string) (uint64, bool) {
+	matches := lowestHeightRegex.FindStringSubmatch(errMsg)
+	if len(matches) < 2 {
+		return 0, false
+	}
+	height, err := strconv.ParseUint(matches[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return height, true
+}
+
 // extractBlocksAndTransactions extracts blocks and transactions from the gRPC server.
+//
+// Pruned Node Handling:
+// When the starting height is below the node's pruning boundary, the gRPC call
+// returns an error like "height X is not available, lowest height is Y". Rather
+// than failing, we parse this error to extract Y and restart extraction from
+// that height. This loop continues until we either complete successfully or hit
+// a non-recoverable error.
+//
+// This approach handles:
+// - Initial misconfiguration where user specifies too-low start height
+// - Mid-extraction discovery that early blocks were pruned during indexing
+// - Nodes with aggressive pruning where --start=1 is common but invalid
 func extractBlocksAndTransactions(gRPCClient *client.GRPCClient, start, stop uint64, outputHandler output.OutputHandler, maxConcurrency, maxRetries uint) error {
-	displayProgress := start != stop
-	if displayProgress {
-		slog.Info("Extracting blocks and transactions", "range", fmt.Sprintf("[%d, %d]", start, stop))
-	} else {
-		slog.Info("Extracting blocks and transactions", "height", start)
-	}
-	var bar *progressbar.ProgressBar
-	if displayProgress {
-		bar = progressbar.NewOptions64(
-			int64(stop-start+1),
-			progressbar.OptionClearOnFinish(),
-			progressbar.OptionSetDescription("Processing blocks..."),
-			progressbar.OptionShowCount(),
-			progressbar.OptionShowIts(),
-			progressbar.OptionSetTheme(progressbar.Theme{
-				Saucer:        "=",
-				SaucerHead:    ">",
-				SaucerPadding: " ",
-				BarStart:      "[",
-				BarEnd:        "]",
-			}),
-		)
-		if err := bar.RenderBlank(); err != nil {
-			return fmt.Errorf("failed to render progress bar: %w", err)
+	currentStart := start
+
+	for {
+		displayProgress := currentStart != stop
+		if displayProgress {
+			slog.Info("Extracting blocks and transactions", "range", fmt.Sprintf("[%d, %d]", currentStart, stop))
+		} else {
+			slog.Info("Extracting blocks and transactions", "height", currentStart)
 		}
-	}
 
-	if err := processBlocks(gRPCClient, start, stop, outputHandler, maxConcurrency, maxRetries, bar); err != nil {
-		return fmt.Errorf("failed to process blocks and transactions: %w", err)
-	}
-
-	if bar != nil {
-		if err := bar.Finish(); err != nil {
-			return fmt.Errorf("failed to finish progress bar: %w", err)
+		var bar *progressbar.ProgressBar
+		if displayProgress {
+			bar = progressbar.NewOptions64(
+				int64(stop-currentStart+1),
+				progressbar.OptionClearOnFinish(),
+				progressbar.OptionSetDescription("Processing blocks..."),
+				progressbar.OptionShowCount(),
+				progressbar.OptionShowIts(),
+				progressbar.OptionSetTheme(progressbar.Theme{
+					Saucer:        "=",
+					SaucerHead:    ">",
+					SaucerPadding: " ",
+					BarStart:      "[",
+					BarEnd:        "]",
+				}),
+			)
+			if err := bar.RenderBlank(); err != nil {
+				return fmt.Errorf("failed to render progress bar: %w", err)
+			}
 		}
-	}
 
-	return nil
+		err := processBlocks(gRPCClient, currentStart, stop, outputHandler, maxConcurrency, maxRetries, bar)
+		if err != nil {
+			// Check if we got a height not available error
+			var heightErr *ErrHeightNotAvailable
+			if errors.As(err, &heightErr) {
+				slog.Info("Restarting extraction from lowest available height",
+					"previousStart", currentStart,
+					"newStart", heightErr.LowestHeight,
+					"blocksSkipped", heightErr.LowestHeight-currentStart)
+				currentStart = heightErr.LowestHeight
+				continue
+			}
+			return fmt.Errorf("failed to process blocks and transactions: %w", err)
+		}
+
+		if bar != nil {
+			if err := bar.Finish(); err != nil {
+				return fmt.Errorf("failed to finish progress bar: %w", err)
+			}
+		}
+
+		return nil
+	}
 }
 
 // processMissingBlocks processes missing blocks by fetching them from the gRPC server.
@@ -101,15 +162,30 @@ func processBlocks(gRPCClient *client.GRPCClient, start, stop uint64, outputHand
 
 			err := processSingleBlockWithRetry(clientWithCtx, blockHeight, outputHandler, maxRetries)
 			if err != nil {
-				if !errors.Is(err, context.Canceled) {
-					slog.Error("Block processing error",
-						"height", blockHeight,
-						"error", err,
-						"errorType", fmt.Sprintf("%T", err))
-					return err
+				// User cancellation takes precedence
+				if errors.Is(err, context.Canceled) {
+					slog.Error("Failed to process block", "height", blockHeight, "error", err, "retries", maxRetries)
+					return fmt.Errorf("failed to process block %d: %w", blockHeight, err)
 				}
-				slog.Error("Failed to process block", "height", blockHeight, "error", err, "retries", maxRetries)
-				return fmt.Errorf("failed to process block %d: %w", blockHeight, err)
+
+				// Pruned node detection: when concurrent workers hit pruned blocks,
+				// propagate ErrHeightNotAvailable to trigger restart from valid height
+				if lowestHeight, ok := parseLowestHeight(err.Error()); ok {
+					slog.Warn("Pruned node detected - adjusting start height",
+						"requestedHeight", blockHeight,
+						"lowestAvailable", lowestHeight,
+						"note", "Blocks before this height are not available on this endpoint and cannot be indexed")
+					return &ErrHeightNotAvailable{
+						RequestedHeight: blockHeight,
+						LowestHeight:    lowestHeight,
+					}
+				}
+
+				slog.Error("Block processing error",
+					"height", blockHeight,
+					"error", err,
+					"errorType", fmt.Sprintf("%T", err))
+				return err
 			}
 
 			if bar != nil {

--- a/internal/extractor/block_test.go
+++ b/internal/extractor/block_test.go
@@ -1,0 +1,87 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLowestHeight(t *testing.T) {
+	cases := []struct {
+		name           string
+		errMsg         string
+		expectedHeight uint64
+		expectedOk     bool
+	}{
+		{
+			name:           "standard error message",
+			errMsg:         "height 60 is not available, lowest height is 28566001",
+			expectedHeight: 28566001,
+			expectedOk:     true,
+		},
+		{
+			name:           "wrapped error message",
+			errMsg:         "failed to get block data: Failed after 3 retries: error invoking method: rpc error: code = Unknown desc = height 60 is not available, lowest height is 28566001",
+			expectedHeight: 28566001,
+			expectedOk:     true,
+		},
+		{
+			name:           "different height values",
+			errMsg:         "height 1 is not available, lowest height is 100",
+			expectedHeight: 100,
+			expectedOk:     true,
+		},
+		{
+			name:           "large height value",
+			errMsg:         "lowest height is 9999999999",
+			expectedHeight: 9999999999,
+			expectedOk:     true,
+		},
+		{
+			name:           "no match - different error",
+			errMsg:         "connection refused",
+			expectedHeight: 0,
+			expectedOk:     false,
+		},
+		{
+			name:           "no match - empty string",
+			errMsg:         "",
+			expectedHeight: 0,
+			expectedOk:     false,
+		},
+		{
+			name:           "no match - partial message",
+			errMsg:         "lowest height is",
+			expectedHeight: 0,
+			expectedOk:     false,
+		},
+		{
+			name:           "no match - non-numeric height",
+			errMsg:         "lowest height is abc",
+			expectedHeight: 0,
+			expectedOk:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			height, ok := parseLowestHeight(tc.errMsg)
+			assert.Equal(t, tc.expectedOk, ok, "ok mismatch")
+			assert.Equal(t, tc.expectedHeight, height, "height mismatch")
+		})
+	}
+}
+
+func TestErrHeightNotAvailable(t *testing.T) {
+	err := &ErrHeightNotAvailable{
+		RequestedHeight: 1,
+		LowestHeight:    28566001,
+	}
+
+	assert.Equal(t, "height 1 is not available, lowest height is 28566001", err.Error())
+
+	// Verify we can parse our own error message
+	height, ok := parseLowestHeight(err.Error())
+	assert.True(t, ok)
+	assert.Equal(t, uint64(28566001), height)
+}

--- a/internal/utils/block.go
+++ b/internal/utils/block.go
@@ -1,15 +1,19 @@
 package utils
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/manifest-network/yaci/internal/client"
 	"github.com/pkg/errors"
 )
 
 const statusMethod = "cosmos.base.node.v1beta1.Service.Status"
+const getBlockByHeightMethod = "cosmos.base.tendermint.v1beta1.Service.GetBlockByHeight"
 
-// GetLatestBlockHeightWithRetry retrieves the latest block height from the gRPC server with retry logic.
+// GetLatestBlockHeightWithRetry gets current block height from Status endpoint
 func GetLatestBlockHeightWithRetry(gRPCClient *client.GRPCClient, maxRetries uint) (uint64, error) {
 	return ExtractGRPCField(
 		gRPCClient,
@@ -24,4 +28,53 @@ func GetLatestBlockHeightWithRetry(gRPCClient *client.GRPCClient, maxRetries uin
 			return height, nil
 		},
 	)
+}
+
+// GetEarliestBlockHeight determines the earliest available block on a node.
+//
+// Strategy:
+// 1. Probe block 1 with minimal retries (pruned nodes fail fast with clear error)
+// 2. If successful, node is an archive node - return 1
+// 3. If error contains "lowest height is X", node is pruned - return X
+// 4. If error is transient (network issue), retry with full retry count
+//
+// This approach minimizes latency for the common case (pruned nodes return
+// immediately with the lowest height) while still handling archive nodes
+// and transient failures gracefully.
+func GetEarliestBlockHeight(gRPCClient *client.GRPCClient, maxRetries uint) (uint64, error) {
+	inputParams := []byte(`{"height":"1"}`)
+
+	// Fast path: single attempt to check if block 1 exists
+	_, err := GetGRPCResponse(gRPCClient, getBlockByHeightMethod, 1, inputParams)
+	if err == nil {
+		return 1, nil // Archive node with full history
+	}
+
+	// Check if error reveals the pruning boundary
+	if lowestHeight := parseLowestHeightFromError(err.Error()); lowestHeight > 0 {
+		return lowestHeight, nil
+	}
+
+	// Error was neither "block exists" nor "pruned" - retry in case of transient failure
+	_, err = GetGRPCResponse(gRPCClient, getBlockByHeightMethod, maxRetries, inputParams)
+	if err == nil {
+		return 1, nil
+	}
+
+	return 0, fmt.Errorf("failed to determine earliest block height: %w", err)
+}
+
+// parseLowestHeightFromError extracts lowest height from pruned node errors
+func parseLowestHeightFromError(errMsg string) uint64 {
+	re := regexp.MustCompile(`lowest height is (\d+)`)
+	matches := re.FindStringSubmatch(strings.ToLower(errMsg))
+
+	if len(matches) >= 2 {
+		height, err := strconv.ParseUint(matches[1], 10, 64)
+		if err == nil {
+			return height
+		}
+	}
+
+	return 0
 }

--- a/internal/utils/grpc_test.go
+++ b/internal/utils/grpc_test.go
@@ -1,0 +1,230 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// createTestMessage creates a test protobuf message with nested structure
+// mimicking the cosmos.base.tendermint.v1beta1.GetLatestBlockResponse structure
+func createTestMessage(t *testing.T) protoreflect.Message {
+	t.Helper()
+
+	// Create nested message descriptors similar to:
+	// Response { height: string, sdk_block: Block { header: Header { height: string, chain_id: string } } }
+	headerDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Header"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   proto.String("height"),
+				Number: proto.Int32(1),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+			{
+				Name:   proto.String("chain_id"),
+				Number: proto.Int32(2),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+		},
+	}
+
+	blockDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Block"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("header"),
+				Number:   proto.Int32(1),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".test.Header"),
+			},
+		},
+	}
+
+	responseDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Response"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   proto.String("height"),
+				Number: proto.Int32(1),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+			{
+				Name:     proto.String("sdk_block"),
+				Number:   proto.Int32(2),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".test.Block"),
+			},
+		},
+	}
+
+	fileDesc := &descriptorpb.FileDescriptorProto{
+		Name:        proto.String("test.proto"),
+		Package:     proto.String("test"),
+		MessageType: []*descriptorpb.DescriptorProto{headerDesc, blockDesc, responseDesc},
+	}
+
+	fd, err := protodesc.NewFile(fileDesc, nil)
+	if err != nil {
+		t.Fatalf("failed to create file descriptor: %v", err)
+	}
+
+	// Create dynamic message and populate it
+	msgDesc := fd.Messages().ByName("Response")
+	if msgDesc == nil {
+		t.Fatal("Response message descriptor not found")
+	}
+
+	msg := dynamicpb.NewMessage(msgDesc)
+
+	// Set flat field: height = "12345"
+	heightField := msgDesc.Fields().ByName("height")
+	msg.Set(heightField, protoreflect.ValueOfString("12345"))
+
+	// Set nested fields: sdk_block.header.height = "67890"
+	sdkBlockField := msgDesc.Fields().ByName("sdk_block")
+	blockMsgDesc := sdkBlockField.Message()
+	blockMsg := dynamicpb.NewMessage(blockMsgDesc)
+
+	headerField := blockMsgDesc.Fields().ByName("header")
+	headerMsgDesc := headerField.Message()
+	headerMsg := dynamicpb.NewMessage(headerMsgDesc)
+
+	nestedHeightField := headerMsgDesc.Fields().ByName("height")
+	headerMsg.Set(nestedHeightField, protoreflect.ValueOfString("67890"))
+
+	chainIdField := headerMsgDesc.Fields().ByName("chain_id")
+	headerMsg.Set(chainIdField, protoreflect.ValueOfString("test-chain"))
+
+	blockMsg.Set(headerField, protoreflect.ValueOfMessage(headerMsg))
+	msg.Set(sdkBlockField, protoreflect.ValueOfMessage(blockMsg))
+
+	return msg
+}
+
+func TestGetNestedField(t *testing.T) {
+	msg := createTestMessage(t)
+
+	cases := []struct {
+		name      string
+		fieldPath string
+		wantValue string
+		wantErr   string
+	}{
+		{
+			name:      "flat field",
+			fieldPath: "height",
+			wantValue: "12345",
+		},
+		{
+			name:      "nested field - two levels",
+			fieldPath: "sdk_block.header",
+			wantValue: "", // Message type, check existence not value
+		},
+		{
+			name:      "nested field - three levels",
+			fieldPath: "sdk_block.header.height",
+			wantValue: "67890",
+		},
+		{
+			name:      "nested field - different leaf",
+			fieldPath: "sdk_block.header.chain_id",
+			wantValue: "test-chain",
+		},
+		{
+			name:      "non-existent field",
+			fieldPath: "nonexistent",
+			wantErr:   "field 'nonexistent' not found",
+		},
+		{
+			name:      "non-existent nested field",
+			fieldPath: "sdk_block.nonexistent",
+			wantErr:   "field 'nonexistent' not found",
+		},
+		{
+			name:      "navigate beyond non-message field",
+			fieldPath: "height.something",
+			wantErr:   "is not a message",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := getNestedField(msg, tc.fieldPath)
+			if tc.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+				if tc.wantValue != "" {
+					assert.Equal(t, tc.wantValue, val.String())
+				} else {
+					// For message types, just verify it's valid
+					assert.True(t, val.IsValid())
+				}
+			}
+		})
+	}
+}
+
+func TestParseMethodFullName(t *testing.T) {
+	cases := []struct {
+		name           string
+		methodFullName string
+		wantService    string
+		wantMethod     string
+		wantErr        string
+	}{
+		{
+			name:           "standard format",
+			methodFullName: "cosmos.tx.v1beta1.Service.GetBlockWithTxs",
+			wantService:    "cosmos.tx.v1beta1.Service",
+			wantMethod:     "GetBlockWithTxs",
+		},
+		{
+			name:           "simple format",
+			methodFullName: "service.Method",
+			wantService:    "service",
+			wantMethod:     "Method",
+		},
+		{
+			name:           "empty string",
+			methodFullName: "",
+			wantErr:        "method full name is empty",
+		},
+		{
+			name:           "no dot",
+			methodFullName: "InvalidMethod",
+			wantErr:        "no dot found",
+		},
+		{
+			name:           "empty service",
+			methodFullName: ".Method",
+			wantErr:        "invalid method full name format",
+		},
+		{
+			name:           "empty method",
+			methodFullName: "service.",
+			wantErr:        "invalid method full name format",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service, method, err := ParseMethodFullName(tc.methodFullName)
+			if tc.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantService, service)
+				assert.Equal(t, tc.wantMethod, method)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Improves yaci's compatibility with different CosmosSDK chains and adds error handling for edge cases encountered in production.

**Pruned Node Support**
- Auto-detect earliest available block instead of hardcoding to 1
- Graceful recovery: when extraction hits pruned blocks, automatically restart from lowest available height
- Workaround for #28: CosmosSDK doesn't expose a dedicated endpoint for earliest available height, so we probe block 1 and parse the error message to extract the lowest height from pruned node errors

**Transaction Error Handling**
- Store error metadata instead of failing entire block when tx fetch fails
- Handles oversized transactions (seen on Mantrachain) and transient RPC failures
- Downstream consumers can identify failed txs via `error` field in JSON

**Nested Field Navigation**
- Add `getNestedField()` to traverse nested protobuf messages with dot notation
- Supports chains with different response structures (e.g., `sdk_block.header.height`)
- Fix typo in error format string (`$%w` -> `%w`)

## Testing

Added unit tests for pruned node error parsing, nested protobuf field traversal, and gRPC method name parsing. All tests in `internal/extractor` and `internal/utils` pass.

Note: Pre-existing flaky test in `internal/metrics/server_test.go` fails due to port binding - unrelated to this PR.

E2E testing against pruned nodes recommended before merge.

## Related

- Workaround for #28 (not a proper fix - relies on error message parsing rather than a dedicated API)